### PR TITLE
Turn off Bootmagic

### DIFF
--- a/keyboards/rpi/pi500/rules.mk
+++ b/keyboards/rpi/pi500/rules.mk
@@ -3,3 +3,4 @@
 # See UART_TX_PIN in config.h
 #UART_DRIVER_REQUIRED = yes # Used for debug via a gpio pin
 #CONSOLE_ENABLE = yes # Enables printf and dprintf
+BOOTMAGIC_ENABLE = no


### PR DESCRIPTION
Turning off bootmagic stops the RP2040 going into bootloader if Q (0,0 on the keyboard matrix) is held when the Pi500 is plugged into power supply.

We probably don't want this behavior as we can still get into the bootloader by setting GPIO pins on the 2712.
