### PR TITLE
Fix compile warning and disable double tap reset into Bootloader

### DIFF
--- a/keyboards/rpi/pi500/config.h
+++ b/keyboards/rpi/pi500/config.h
@@ -15,9 +15,6 @@
 // Sets the flash to run in DSPI mode rather than QSPI
 #define RP2040_FLASH_W25X10CL 
 
-#define MATRIX_ROWS 8
-#define MATRIC_COLS 16
-
 // Crucial to the function of the keyboard when the Pi is off. Ignores USB
 #define NO_USB_STARTUP_CHECK
 

--- a/keyboards/rpi/pi500/config.h
+++ b/keyboards/rpi/pi500/config.h
@@ -9,11 +9,10 @@
  */
 
 // Double tap reset to go into bootloader definitions:
-#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET
-#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT 500U
+#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT 0
 
 // Sets the flash to run in DSPI mode rather than QSPI
-#define RP2040_FLASH_W25X10CL 
+#define RP2040_FLASH_W25X10CL
 
 // Crucial to the function of the keyboard when the Pi is off. Ignores USB
 #define NO_USB_STARTUP_CHECK

--- a/keyboards/rpi/pi500/keyboard.json
+++ b/keyboards/rpi/pi500/keyboard.json
@@ -3,7 +3,7 @@
     "manufacturer": "Raspberry Pi Ltd",
     "maintainer": "Raspberry Pi",
     "features": {
-        "bootmagic": true,
+        "bootmagic": false,
         "console": false,
         "extrakey": true,
         "mousekey": true,

--- a/keyboards/rpi/pi500/rules.mk
+++ b/keyboards/rpi/pi500/rules.mk
@@ -3,4 +3,3 @@
 # See UART_TX_PIN in config.h
 #UART_DRIVER_REQUIRED = yes # Used for debug via a gpio pin
 #CONSOLE_ENABLE = yes # Enables printf and dprintf
-BOOTMAGIC_ENABLE = no


### PR DESCRIPTION
- Disabled Bootmagic in keyboard.json and removed it from rules.mk to fix a compile warning
- Disabled double tap reset into Bootloader by setting its timeout to 0
Also to tidy up:
- Removed MATRIX_ROWS and MATRIX_COLUMNS defines as they are not needed 
